### PR TITLE
(mGBA Wii core) Decrease Audio Buffer Samples for improve emulation speed

### DIFF
--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -25,7 +25,7 @@
 #include <mgba-util/memory.h>
 #include <mgba-util/vfs.h>
 
-#define SAMPLES 1024
+#define SAMPLES 128
 #define RUMBLE_PWM 35
 
 static retro_environment_t environCallback;

--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -25,7 +25,7 @@
 #include <mgba-util/memory.h>
 #include <mgba-util/vfs.h>
 
-#define SAMPLES 128
+#define SAMPLES 512
 #define RUMBLE_PWM 35
 
 static retro_environment_t environCallback;


### PR DESCRIPTION
Hi @SuperrSonic, i hope you apply this small contribution to your mGBA Wii core in a next version of RA-HEXAECO.

This "small" modification increases the speed and stability of emulation.
Based on fix by @zerofalcon on Libretro's mGBA Wii.
More info see here: https://github.com/zerofalcon/mgba/commit/2d3d432103ffedb4e0824f088a08cd0d663d8cb6
See also: https://forums.libretro.com/t/wii-mgba-core-executing-almost-100-fast/3207

EDIT: The official Libretro mGBA core for Wii has audio buffer samples set to 512 instead of this sugested fix of set up the samples to 128 as shown in the fix by @zerofalcon, but it's your decision to put it in 128 (@zerofalcon's fix) or 512 (official Libretro mGBA Wii core setting).

If you want to see the mod for change audio buffer samples to 512 (Libretro), see this commit: https://github.com/saulfabregwiivc/mgba/commit/cb1613eeb85f7882f7a6096cc03d27972df28291
For see the mod for change audio buffer samples to 128 (@zerofalcon), see this commit: 
https://github.com/saulfabregwiivc/mgba/commit/ac04e44247caeab5da9ef845fe9c98c8781d2d30

Greetings, @saulfabregwiivc